### PR TITLE
mejora de palabras traducidas y links internos  

### DIFF
--- a/01_values.md
+++ b/01_values.md
@@ -173,7 +173,7 @@ Sin embargo, hay una complicación: la representación de JavaScript utiliza 16 
 Las cadenas no se pueden dividir, multiplicar o restar. El operador `+` se puede usar en ellas, no para sumar, sino para _concatenar_ —unir dos cadenas. La siguiente línea producirá la cadena `"concatenar"`:
 
 ```{meta: "expr"}
-"con" + "cat" + "e" + "nate"
+"con" + "cat" + "e" + "nar"
 ```
 
 Los valores de cadena tienen una serie de funciones asociadas (_métodos_) que se pueden utilizar para realizar otras operaciones con ellos. Hablaré más sobre esto en [Capítulo ?](data#methods).

--- a/02_program_structure.md
+++ b/02_program_structure.md
@@ -16,7 +16,7 @@ En este capítulo, comenzaremos a hacer cosas que realmente pueden ser llamadas 
 
 {{index grammar, [sintaxis, "expresión"], ["código", "estructura de"], "gramática", [JavaScript, sintaxis]}}
 
-En [Capítulo ?](valores), creamos valores y aplicamos operadores a ellos para obtener nuevos valores. Crear valores de esta manera es la sustancia principal de cualquier programa JavaScript. Pero esa sustancia debe enmarcarse en una estructura más grande para ser útil. Eso es lo que cubriremos en este capítulo.
+En [Capítulo 1](01_values), creamos valores y aplicamos operadores a ellos para obtener nuevos valores. Crear valores de esta manera es la sustancia principal de cualquier programa JavaScript. Pero esa sustancia debe enmarcarse en una estructura más grande para ser útil. Eso es lo que cubriremos en este capítulo.
 
 {{index "expresión literal", ["paréntesis", "expresión"]}}
 


### PR DESCRIPTION
arregle la traduccion de la palabra concatenate: 
antes: 
![Captura de pantalla 2024-03-14 072150](https://github.com/midudev/eloquent-javascript-es/assets/122571870/0f491b9b-d166-4daa-8efa-e755e58c1fa7)

desp: 
![Captura de pantalla 2024-03-14 072217](https://github.com/midudev/eloquent-javascript-es/assets/122571870/cdd5fbdc-9885-4786-9f21-fcf0db3defe3)

y el link interno que lleva al capitulo 1 de valores 01_values
antes: 
![Captura de pantalla 2024-03-14 072934](https://github.com/midudev/eloquent-javascript-es/assets/122571870/d373637e-cc27-4253-a874-e9d8013a35a4)

desp:
![Captura de pantalla 2024-03-14 072946](https://github.com/midudev/eloquent-javascript-es/assets/122571870/c06d5f29-2602-4343-8075-0394da661f97)
