### PR TITLE
fix error text in chapter 7

### DIFF
--- a/07_robot.md
+++ b/07_robot.md
@@ -29,9 +29,9 @@ const roads = [
   "Casa de Alice-Oficina de Correos","Casa de Bob-Ayuntamiento",
   "Casa de Daria-Casa de Ernie","Casa de Daria-Ayuntamiento",
   "Casa de Ernie-Casa de Grete","Casa de Grete-Granja",
-  "Casa de Grete-Tienda","Plaza de Mercado-Granja",
-  "Plaza de Mercado-Oficina de Correos","Plaza de Mercado-Tienda",
-  "Plaza de Mercado-Ayuntamiento","Tienda-Ayuntamiento"
+  "Casa de Grete-Tienda","Plaza del Mercado-Granja",
+  "Plaza del Mercado-Oficina de Correos","Plaza del Mercado-Tienda",
+  "Plaza del Mercado-Ayuntamiento","Tienda-Ayuntamiento"
 ];
 ```
 


### PR DESCRIPTION
 se cambio en el array roads el elemento "Plaza de Mercado"  a "Plaza del Mercado"  para coincidir con el array 
mailRoute que tiene el elemento como "Plaza del Mercado"

para evitar errores al copiar el codigo  :smile: 

