### PR TITLE
Usar flechitas derecha e izquierda para moverse entre capitulos

### DIFF
--- a/src/client/ejs.mjs
+++ b/src/client/ejs.mjs
@@ -23,6 +23,20 @@ function chapterInteraction() {
         editor.focus()
       }
     }
+    if (e.key == "ArrowRight") {
+      let nextChapter = document.querySelector("a[aria-label='next chapter']")
+      if (nextChapter) {
+        e.preventDefault()
+        nextChapter.click()
+      }
+    }
+    if (e.key == "ArrowLeft") {
+      let previousChapter = document.querySelector("a[aria-label='previous chapter']")
+      if (previousChapter) {
+        e.preventDefault()
+        previousChapter.click()
+      }
+    }
   })
 
   let modName = /Mac/.test(navigator.platform) ? "Cmd-" : "Ctrl-"

--- a/src/client/ejs.mjs
+++ b/src/client/ejs.mjs
@@ -23,20 +23,6 @@ function chapterInteraction() {
         editor.focus()
       }
     }
-    if (e.key == "ArrowRight") {
-      let nextChapter = document.querySelector("a[aria-label='next chapter']")
-      if (nextChapter) {
-        e.preventDefault()
-        nextChapter.click()
-      }
-    }
-    if (e.key == "ArrowLeft") {
-      let previousChapter = document.querySelector("a[aria-label='previous chapter']")
-      if (previousChapter) {
-        e.preventDefault()
-        previousChapter.click()
-      }
-    }
   })
 
   let modName = /Mac/.test(navigator.platform) ? "Cmd-" : "Ctrl-"
@@ -353,8 +339,32 @@ function debounce(fn, delay = 50) {
   }
 }
 
+function navigateBetweenChapters() {
+  document.addEventListener("keydown", e => {
+    let activeElement = document.activeElement
+
+    if (activeElement && activeElement.contentEditable === "true" || activeElement.nodeName === "INPUT") return
+
+    if (e.key === "ArrowRight") {
+      let nextChapter = document.querySelector("a[aria-label='next chapter']")
+      if (nextChapter) {
+        e.preventDefault()
+        nextChapter.click()
+      }
+    }
+    if (e.key === "ArrowLeft") {
+      let previousChapter = document.querySelector("a[aria-label='previous chapter']")
+      if (previousChapter) {
+        e.preventDefault()
+        previousChapter.click()
+      }
+    }
+  })
+}
+
 if (window.page && /^chapter|hints$/.test(window.page.type)) {
   chapterInteraction()
+  navigateBetweenChapters()
   // 3rd-edition-style anchor
   let {hash} = document.location
   if (/^#[phic]_./.test(hash)) {


### PR DESCRIPTION
Me encontraba leyendo el libro y pensé que poder usar las flechitas para cambiar entre capítulos es más cómodo para moverse.

Para poder probar si funcionaban los cambios que realicé, corrí este comando `node_modules/.bin/rollup -c src/client/rollup.config.mjs` porque no puedo hacer funcionar el Makefile (supongo que es por incompatibilidades con windows).